### PR TITLE
frontend: move operator pages off render-triggered loading

### DIFF
--- a/apps/web/app/approvals-queue/page.tsx
+++ b/apps/web/app/approvals-queue/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiGet } from "@/lib/api/client";
 import { ReleaseApprovalPanel } from "@/components/approvals/release-approval-panel";
 
@@ -13,8 +13,10 @@ type Release = {
 export default function ApprovalsQueuePage() {
   const [release, setRelease] = useState<Release | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasLoaded = useRef(false);
 
   async function loadData() {
+    setLoading(true);
     try {
       const data = await apiGet<Release>("/api/v1/releases/REL-2026.04.3");
       setRelease(data);
@@ -23,8 +25,16 @@ export default function ApprovalsQueuePage() {
     }
   }
 
+  useEffect(() => {
+    if (hasLoaded.current) {
+      return;
+    }
+
+    hasLoaded.current = true;
+    void loadData();
+  }, []);
+
   if (loading && !release) {
-    loadData();
     return <div>Loading...</div>;
   }
 

--- a/apps/web/app/audit-log/page.tsx
+++ b/apps/web/app/audit-log/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiGet, apiPost } from "@/lib/api/client";
 
 type AuditEvent = {
@@ -18,8 +18,10 @@ export default function AuditLogPage() {
   const [loading, setLoading] = useState(true);
   const [filterActor, setFilterActor] = useState("");
   const [filterAction, setFilterAction] = useState("");
+  const hasLoaded = useRef(false);
 
   async function loadAudit() {
+    setLoading(true);
     try {
       await apiPost("/api/v1/evals/run");
       const audit = await apiGet<AuditEvent[]>("/api/v1/audit");
@@ -29,8 +31,16 @@ export default function AuditLogPage() {
     }
   }
 
+  useEffect(() => {
+    if (hasLoaded.current) {
+      return;
+    }
+
+    hasLoaded.current = true;
+    void loadAudit();
+  }, []);
+
   if (loading && events.length === 0) {
-    loadAudit();
     return <div>Loading audit events...</div>;
   }
 
@@ -109,4 +119,3 @@ export default function AuditLogPage() {
     </section>
   );
 }
-

--- a/apps/web/app/release-center/page.tsx
+++ b/apps/web/app/release-center/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiGet } from "@/lib/api/client";
 import { ReleaseApprovalPanel } from "@/components/approvals/release-approval-panel";
 import { ReleaseOverridePanel } from "@/components/approvals/release-override-panel";
@@ -23,8 +23,10 @@ type Release = {
 export default function ReleaseCenterPage() {
   const [data, setData] = useState<{ release: Release; readiness: ReleaseReadiness } | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasLoaded = useRef(false);
 
   async function loadData() {
+    setLoading(true);
     try {
       const releases = await apiGet<Release[]>("/api/v1/releases");
       const selected = releases[0];
@@ -35,8 +37,16 @@ export default function ReleaseCenterPage() {
     }
   }
 
+  useEffect(() => {
+    if (hasLoaded.current) {
+      return;
+    }
+
+    hasLoaded.current = true;
+    void loadData();
+  }, []);
+
   if (loading && !data) {
-    loadData();
     return <div>Loading...</div>;
   }
 

--- a/apps/web/app/reviewer-recommendations/page.tsx
+++ b/apps/web/app/reviewer-recommendations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { apiGet } from "@/lib/api/client";
 
 type ReviewerRecommendation = {
@@ -15,8 +15,10 @@ type PR = { id: string; title: string };
 export default function ReviewerRecommendationsPage() {
   const [data, setData] = useState<{ pr: PR; reviewers: ReviewerRecommendation[] } | null>(null);
   const [loading, setLoading] = useState(true);
+  const hasLoaded = useRef(false);
 
   async function loadData() {
+    setLoading(true);
     try {
       const prs = await apiGet<PR[]>("/api/v1/pull-requests");
       const selected = prs[0];
@@ -27,8 +29,16 @@ export default function ReviewerRecommendationsPage() {
     }
   }
 
+  useEffect(() => {
+    if (hasLoaded.current) {
+      return;
+    }
+
+    hasLoaded.current = true;
+    void loadData();
+  }, []);
+
   if (loading && !data) {
-    loadData();
     return <div>Loading...</div>;
   }
 


### PR DESCRIPTION
## Summary

Move `release-center`, `approvals-queue`, `reviewer-recommendations`, and `audit-log` off render-triggered async loading and onto an explicit initial-load effect.

This keeps those routes from firing network work during render and prevents the audit route from repeatedly kicking off eval runs when the component re-renders.

Closes #1.

## Scope

- What changed
  - moved the initial fetch for the four affected operator pages into `useEffect`
  - added a `useRef` guard so the initial load only runs once per mount path
  - set loading state explicitly at the start of each refresh path so panel-driven reloads stay consistent
- What did not change
  - no product copy, data model, or route behavior was redesigned
  - no new abstraction or shared hook was introduced in this PR
- Any follow-up work intentionally left out
  - the rest of the backlog item around smoke coverage and route verification stays separate

## Verification

- Commands run:
  - `npm run build`
- Manual checks:
  - reviewed the affected routes to confirm they no longer invoke async work from render branches
- Screenshots or API examples:
  - not needed for this internal loading-path fix

## Risk

- User-facing risk:
  - low; the change only affects when initial requests are started
- Operational or data risk:
  - low; this reduces duplicate requests, especially on the audit route that also triggers eval execution
- Rollback path:
  - revert commit `88e08cc`

## Checklist

- [x] The branch is scoped to one concern
- [x] Commit messages are meaningful from the history alone
- [x] Tests or equivalent verification were run, or the gap is called out
- [x] Docs were updated if workflow, behavior, or screenshots changed
- [x] Risky logic changes are called out explicitly
