### PR TITLE
backend: allow localhost and 127.0.0.1 local web origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ VANGUARD_LOG_LEVEL=INFO
 # API
 API_HOST=0.0.0.0
 API_PORT=8080
-API_CORS_ORIGINS=http://localhost:3000
+API_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 DATASET_ROOT=/workspace/datasets
 
 # Database and infra

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ curl http://localhost:8080/api/v1/pull-requests
 open http://localhost:3000
 ```
 
+The default local CORS configuration allows both `http://localhost:3000` and `http://127.0.0.1:3000`. If you override `API_CORS_ORIGINS`, keep both entries unless you intentionally want a stricter local setup.
+
 ## Repository Structure
 
 ```text

--- a/apps/api/app/config/settings.py
+++ b/apps/api/app/config/settings.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     vanguard_log_level: str = "INFO"
     api_host: str = "0.0.0.0"
     api_port: int = 8080
-    api_cors_origins: str = "http://localhost:3000"
+    api_cors_origins: str = "http://localhost:3000,http://127.0.0.1:3000"
     dataset_root: str = "/workspace/datasets"
     postgres_url: str = "postgresql+psycopg://vanguard:vanguard@postgres:5432/vanguard"
     redis_url: str = "redis://redis:6379/0"
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     opensearch_url: str = "http://opensearch:9200"
     llm_provider: str = "deterministic-local"
     llm_model: str = "vanguard-grounded-v1"
+
+    @property
+    def cors_origins(self) -> list[str]:
+        return [item.strip() for item in self.api_cors_origins.split(",") if item.strip()]
 
 
 @lru_cache(maxsize=1)

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,67 +1,70 @@
 import time
 import uuid
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from app.config.settings import get_settings
-from app.core.errors import VanguardError
-from app.core.logging import configure_logging, request_id_ctx
 from app.api.v1.routes.health import router as health_router
+from app.api.v1.routes.misc import router as misc_router
+from app.api.v1.routes.policies import router as policy_router
 from app.api.v1.routes.pull_requests import router as pr_router
 from app.api.v1.routes.releases import router as release_router
 from app.api.v1.routes.services import router as service_router
-from app.api.v1.routes.policies import router as policy_router
-from app.api.v1.routes.misc import router as misc_router
-
-settings = get_settings()
-configure_logging(settings.vanguard_log_level)
-
-app = FastAPI(title="VANGUARD API", version="0.1.0")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[item.strip() for item in settings.api_cors_origins.split(",")],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+from app.config.settings import get_settings
+from app.core.errors import VanguardError
+from app.core.logging import configure_logging, request_id_ctx
 
 
-@app.middleware("http")
-async def add_request_context(request: Request, call_next):
-    request_id = request.headers.get("x-request-id", str(uuid.uuid4()))
-    token = request_id_ctx.set(request_id)
-    start = time.perf_counter()
-    try:
-        response = await call_next(request)
-        elapsed_ms = int((time.perf_counter() - start) * 1000)
-        response.headers["x-request-id"] = request_id
-        response.headers["x-latency-ms"] = str(elapsed_ms)
-        return response
-    finally:
-        request_id_ctx.reset(token)
+def create_app() -> FastAPI:
+    settings = get_settings()
+    configure_logging(settings.vanguard_log_level)
 
+    app = FastAPI(title="VANGUARD API", version="0.1.0")
 
-@app.exception_handler(VanguardError)
-async def vanguard_error_handler(_: Request, exc: VanguardError):
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={"error": {"code": exc.code, "message": exc.message}},
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
 
+    @app.middleware("http")
+    async def add_request_context(request: Request, call_next):
+        request_id = request.headers.get("x-request-id", str(uuid.uuid4()))
+        token = request_id_ctx.set(request_id)
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            response.headers["x-request-id"] = request_id
+            response.headers["x-latency-ms"] = str(elapsed_ms)
+            return response
+        finally:
+            request_id_ctx.reset(token)
 
-@app.exception_handler(Exception)
-async def unhandled_error_handler(_: Request, exc: Exception):
-    return JSONResponse(
-        status_code=500,
-        content={"error": {"code": "internal_error", "message": str(exc)}},
-    )
+    @app.exception_handler(VanguardError)
+    async def vanguard_error_handler(_: Request, exc: VanguardError):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    @app.exception_handler(Exception)
+    async def unhandled_error_handler(_: Request, exc: Exception):
+        return JSONResponse(
+            status_code=500,
+            content={"error": {"code": "internal_error", "message": str(exc)}},
+        )
+
+    app.include_router(health_router)
+    app.include_router(pr_router)
+    app.include_router(release_router)
+    app.include_router(service_router)
+    app.include_router(policy_router)
+    app.include_router(misc_router)
+    return app
 
 
-app.include_router(health_router)
-app.include_router(pr_router)
-app.include_router(release_router)
-app.include_router(service_router)
-app.include_router(policy_router)
-app.include_router(misc_router)
+app = create_app()

--- a/apps/api/tests/smoke/test_cors.py
+++ b/apps/api/tests/smoke/test_cors.py
@@ -1,0 +1,29 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config.settings import get_settings
+from app.main import create_app
+
+
+@pytest.mark.parametrize(
+    "origin",
+    ["http://localhost:3000", "http://127.0.0.1:3000"],
+)
+def test_cors_allows_local_web_origins(monkeypatch: pytest.MonkeyPatch, origin: str) -> None:
+    monkeypatch.setenv("API_CORS_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000")
+    get_settings.cache_clear()
+
+    try:
+        client = TestClient(create_app())
+        response = client.options(
+            "/health",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin


### PR DESCRIPTION
## Summary

Allow the local web app to call the API from either `http://localhost:3000` or `http://127.0.0.1:3000` without tripping the default CORS policy.

This fixes the host-name mismatch that showed up during screenshot automation and makes local browser access less fragile.

Closes #4.

## Scope

- What changed
  - expanded the default API CORS origin list to include both local web hosts
  - added a small `cors_origins` settings helper so middleware setup does not re-parse the string inline
  - introduced `create_app()` so the CORS configuration can be tested cleanly with environment overrides
  - added a smoke test covering both allowed origins
  - documented the expected local CORS behavior in `README.md` and `.env.example`
- What did not change
  - the API base URL resolution on the web side is unchanged in this PR
  - no production deployment policy or external ingress config was changed
- Any follow-up work intentionally left out
  - broader local URL normalization on the frontend can stay separate if more host-related behavior shows up

## Verification

- Commands run:
  - `./.venv/bin/pytest -q apps/api/tests`
- Manual checks:
  - reviewed the CORS middleware path and local setup docs after the config change
- Screenshots or API examples:
  - not needed for this API/config fix

## Risk

- User-facing risk:
  - low; this only broadens the default local dev origins from one loopback host to two
- Operational or data risk:
  - low; the change is limited to local browser origins on port 3000 and does not widen to arbitrary hosts
- Rollback path:
  - revert commit `d36014f`

## Checklist

- [x] The branch is scoped to one concern
- [x] Commit messages are meaningful from the history alone
- [x] Tests or equivalent verification were run, or the gap is called out
- [x] Docs were updated if workflow, behavior, or screenshots changed
- [x] Risky logic changes are called out explicitly
