### PR TITLE
tests: cover seeded risk policy and release decisions

### DIFF
--- a/apps/api/tests/services/test_policy_service.py
+++ b/apps/api/tests/services/test_policy_service.py
@@ -1,0 +1,55 @@
+from app.services.graph_service import graph_service
+from app.services.data_store import get_data_store
+from app.services.pr_service import pr_service
+from app.services.policy_service import policy_service
+from app.services.risk_service import risk_service
+
+
+def score_seeded_pr(pr_id: str):
+    pr = pr_service.get_pull_request(pr_id)
+    ci = pr_service.get_ci(pr_id)
+    tests = pr_service.get_tests(pr_id)
+    impacted_services, blast_depth = graph_service.impacted_services(pr.linked_services)
+    protected_touches = sum(
+        1 for changed_file in pr.changed_files if changed_file.path.startswith(("configs/", "security/", "infra/"))
+    )
+    critical_service_count = sum(1 for service in impacted_services if service in {"svc-payments", "svc-auth"})
+    return risk_service.score(
+        pr=pr,
+        ci=ci,
+        tests=tests,
+        protected_touches=protected_touches,
+        critical_service_count=critical_service_count,
+        dependency_depth=blast_depth,
+    )
+
+
+def test_policy_service_blocks_seeded_auth_config_change() -> None:
+    findings = policy_service.evaluate(
+        get_data_store().policies(),
+        pr_service.get_pull_request("PR-3413"),
+        score_seeded_pr("PR-3413"),
+    )
+
+    auth_policy = next(finding for finding in findings if finding.policy_id == "POL-AUTH-CONFIG-SECURITY")
+    release_blocker = next(finding for finding in findings if finding.policy_id == "POL-HIGH-RISK-BLOCKER")
+
+    assert auth_policy.status == "blocked"
+    assert auth_policy.required_team == "team-security"
+    assert "requires team-security approval" in auth_policy.rationale
+    assert release_blocker.status == "pass"
+
+
+def test_policy_service_blocks_high_risk_pr_in_release_mode() -> None:
+    findings = policy_service.evaluate(
+        get_data_store().policies(),
+        pr_service.get_pull_request("PR-3413"),
+        score_seeded_pr("PR-3413"),
+        release_mode=True,
+    )
+
+    release_blocker = next(finding for finding in findings if finding.policy_id == "POL-HIGH-RISK-BLOCKER")
+
+    assert release_blocker.status == "blocked"
+    assert release_blocker.severity == "critical"
+    assert release_blocker.rationale == "High-risk pull request exists and no override is registered."

--- a/apps/api/tests/services/test_release_service.py
+++ b/apps/api/tests/services/test_release_service.py
@@ -1,0 +1,35 @@
+from app.services.release_service import ReleaseService
+
+
+def test_release_readiness_blocks_seeded_release_without_override_or_security_approval() -> None:
+    service = ReleaseService()
+
+    readiness = service.readiness("REL-2026.04.3")
+
+    assert readiness.status == "blocked"
+    assert readiness.score == 50
+    assert readiness.unresolved_high_risk_prs == ["PR-3412", "PR-3413"]
+    assert "High-risk pull requests require override or mitigation." in readiness.blockers
+    assert "Required approval missing for team-security." in readiness.blockers
+    assert readiness.policy_blockers == ["Required approval missing for team-security."]
+
+
+def test_release_readiness_is_ready_for_low_risk_fully_approved_candidate() -> None:
+    service = ReleaseService()
+    baseline = service.get_release("REL-2026.04.3").model_copy(deep=True)
+    baseline.id = "REL-LOW-RISK"
+    baseline.name = "Low Risk Validation Candidate"
+    baseline.pr_ids = ["PR-3414"]
+    baseline.approvals[1].approved = True
+    baseline.approvals[1].actor = "nora"
+    baseline.override = {"active": False, "actor": None, "rationale": None}
+    service._releases.append(baseline)
+
+    readiness = service.readiness("REL-LOW-RISK")
+
+    assert readiness.status == "ready"
+    assert readiness.score == 100
+    assert readiness.blockers == []
+    assert readiness.unresolved_high_risk_prs == []
+    assert readiness.policy_blockers == []
+    assert readiness.notes == "Release is ready for deployment."

--- a/apps/api/tests/services/test_risk_service.py
+++ b/apps/api/tests/services/test_risk_service.py
@@ -1,0 +1,41 @@
+from app.services.graph_service import graph_service
+from app.services.pr_service import pr_service
+from app.services.risk_service import risk_service
+
+
+def score_seeded_pr(pr_id: str):
+    pr = pr_service.get_pull_request(pr_id)
+    ci = pr_service.get_ci(pr_id)
+    tests = pr_service.get_tests(pr_id)
+    impacted_services, blast_depth = graph_service.impacted_services(pr.linked_services)
+    protected_touches = sum(
+        1 for changed_file in pr.changed_files if changed_file.path.startswith(("configs/", "security/", "infra/"))
+    )
+    critical_service_count = sum(1 for service in impacted_services if service in {"svc-payments", "svc-auth"})
+    return risk_service.score(
+        pr=pr,
+        ci=ci,
+        tests=tests,
+        protected_touches=protected_touches,
+        critical_service_count=critical_service_count,
+        dependency_depth=blast_depth,
+    )
+
+
+def test_risk_service_flags_seeded_high_risk_auth_change() -> None:
+    risk = score_seeded_pr("PR-3413")
+
+    assert risk.score == 99
+    assert risk.severity == "critical"
+    assert risk.confidence == 0.7
+    assert "CI signal is not fully green." in risk.warnings
+    assert "Coverage drop exceeds recommended threshold." in risk.warnings
+
+
+def test_risk_service_keeps_seeded_low_risk_metrics_cleanup_low() -> None:
+    risk = score_seeded_pr("PR-3414")
+
+    assert risk.score == 16
+    assert risk.severity == "low"
+    assert risk.confidence == 1.0
+    assert risk.warnings == []


### PR DESCRIPTION
## Summary

Add focused backend tests around the seeded decision paths that drive VANGUARD's core credibility: risk scoring, policy evaluation, and release readiness.

This turns the existing seeded examples into an executable regression signal instead of leaving those decision paths mostly untested.

Closes #2.

## Scope

- What changed
  - added seeded risk scoring assertions for a critical auth/config change and a low-risk observability cleanup
  - added policy evaluation coverage for both normal PR mode and release mode
  - added release readiness coverage for both the seeded blocked release and a low-risk fully approved candidate path
- What did not change
  - no API behavior, score thresholds, or policy rules were changed
  - no dataset values were modified in this PR
- Any follow-up work intentionally left out
  - endpoint-level contract testing stays separate from these service-level assertions

## Verification

- Commands run:
  - `./.venv/bin/pytest -q apps/api/tests`
- Manual checks:
  - matched test expectations against the seeded PR and release scenarios before writing assertions
- Screenshots or API examples:
  - not needed for backend test coverage

## Risk

- User-facing risk:
  - none; test-only change
- Operational or data risk:
  - low; the main risk is brittle assertions if seeded datasets change intentionally later
- Rollback path:
  - revert commit `261da2c`

## Checklist

- [x] The branch is scoped to one concern
- [x] Commit messages are meaningful from the history alone
- [x] Tests or equivalent verification were run, or the gap is called out
- [x] Docs were updated if workflow, behavior, or screenshots changed
- [x] Risky logic changes are called out explicitly
