### PR TITLE
infra: add smoke coverage for key operator routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,68 @@ jobs:
 
       - name: Build web app
         run: npm run build
+
+  web-smoke:
+    runs-on: ubuntu-latest
+    needs:
+      - api
+      - web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install API dependencies
+        working-directory: apps/api
+        run: uv pip install --system -e .[dev]
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      - name: Build web app
+        working-directory: apps/web
+        run: npm run build
+
+      - name: Install Playwright browser
+        working-directory: apps/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Start API server
+        working-directory: apps/api
+        run: |
+          uv run uvicorn app.main:app --host 127.0.0.1 --port 8080 > /tmp/vanguard-api.log 2>&1 &
+
+      - name: Start web server
+        working-directory: apps/web
+        run: |
+          NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 npm run start > /tmp/vanguard-web.log 2>&1 &
+
+      - name: Wait for local services
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:8080/health > /dev/null && curl -sf http://127.0.0.1:3000 > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "API log:"
+          cat /tmp/vanguard-api.log || true
+          echo "Web log:"
+          cat /tmp/vanguard-web.log || true
+          exit 1
+
+      - name: Run operator route smoke checks
+        working-directory: apps/web
+        run: npm run smoke

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start -p 3000",
     "lint": "next lint",
     "test": "echo 'No web tests configured yet'",
-    "screenshots": "node scripts/capture-ui-previews.mjs"
+    "screenshots": "node scripts/capture-ui-previews.mjs",
+    "smoke": "node scripts/smoke-routes.mjs"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.52.2",

--- a/apps/web/scripts/smoke-routes.mjs
+++ b/apps/web/scripts/smoke-routes.mjs
@@ -1,0 +1,64 @@
+import process from "node:process";
+import { chromium } from "playwright";
+
+const baseUrl = process.env.SMOKE_BASE_URL || "http://localhost:3000";
+
+const routes = [
+  { path: "/", label: "dashboard", text: "Delivery Intelligence Dashboard" },
+  { path: "/pr-workspace", label: "pr-workspace", text: "PR Workspace", afterLoad: waitForPrWorkspaceOptions },
+  { path: "/release-center", label: "release-center", text: "Release Center", afterLoad: waitForReleaseData },
+  { path: "/policy-center", label: "policy-center", text: "Policy Center", afterLoad: waitForPolicyEvaluation },
+];
+
+async function waitForPrWorkspaceOptions(page) {
+  await page.locator("select").waitFor({ state: "visible", timeout: 30000 });
+  await page.waitForFunction(() => {
+    const selectElement = document.querySelector("select");
+    return Boolean(selectElement && selectElement.querySelectorAll("option").length > 0);
+  });
+}
+
+async function waitForReleaseData(page) {
+  await page.getByText("Readiness Score", { exact: false }).waitFor({ state: "visible", timeout: 30000 });
+}
+
+async function waitForPolicyEvaluation(page) {
+  await page.getByText("Evaluation Result", { exact: false }).waitFor({ state: "visible", timeout: 30000 });
+}
+
+async function verifyRoute(page, route) {
+  const response = await page.goto(`${baseUrl}${route.path}`, { waitUntil: "domcontentloaded" });
+  if (!response || !response.ok()) {
+    throw new Error(`Route ${route.label} failed to load: ${response?.status() ?? "no response"}`);
+  }
+
+  await page.waitForLoadState("networkidle");
+  await page.getByText(route.text, { exact: false }).first().waitFor({ state: "visible", timeout: 30000 });
+
+  if (route.afterLoad) {
+    await route.afterLoad(page);
+  }
+}
+
+async function main() {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+
+  try {
+    for (const route of routes) {
+      console.log(`Checking ${route.label} at ${route.path}`);
+      await verifyRoute(page, route);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Add route-level smoke coverage for the main operator surfaces and run it in CI against live local API and web servers.

This reopens the smoke-coverage change directly on top of `main` after the earlier stacked PR closed automatically when its base branch was deleted during merge.

Closes #3.

## Scope

- What changed
  - added a Playwright-backed smoke script for `/`, `/pr-workspace`, `/release-center`, and `/policy-center`
  - added an npm `smoke` script in `apps/web/package.json`
  - extended GitHub Actions CI with a `web-smoke` job that builds the app, boots API and web servers, waits for readiness, and runs the route checks
- What did not change
  - no product UI or route copy was redesigned in this PR
  - no screenshot assets were regenerated here
- Any follow-up work intentionally left out
  - broader browser coverage and richer assertion depth can come later if the app grows beyond smoke-level verification

## Verification

- Commands run:
  - `npm run build`
  - `npm run smoke`
- Manual checks:
  - started local API and web servers and confirmed the smoke script passed against the four target routes
- Screenshots or API examples:
  - not needed for this CI/smoke coverage change

## Risk

- User-facing risk:
  - low; this adds test and CI coverage only
- Operational or data risk:
  - low to moderate; the CI job now depends on Playwright browser install and local server startup order
- Rollback path:
  - revert commit `d1286c3`

## Checklist

- [x] The branch is scoped to one concern
- [x] Commit messages are meaningful from the history alone
- [x] Tests or equivalent verification were run, or the gap is called out
- [x] Docs were updated if workflow, behavior, or screenshots changed
- [x] Risky logic changes are called out explicitly
